### PR TITLE
Cleaning up library: resolving TODOs, making components public, adding more customizability for developers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     // Kotlin X
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationJsonVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinxCoroutinesVersion")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinxCoroutinesVersion")
 
     // Ktor
     implementation("io.ktor:ktor-client-core:$ktorVersion")

--- a/src/main/kotlin/dev/sublab/substrate/SubstrateClient.kt
+++ b/src/main/kotlin/dev/sublab/substrate/SubstrateClient.kt
@@ -85,7 +85,7 @@ class SubstrateClient(
         codecProvider.applyRuntimeMetadata(getRuntime())
 
         // Init after dependencies set
-        lookup = SubstrateLookupService(getRuntime(), settings.namingPolicy)
+        lookup = SubstrateLookupService(getRuntime(), settings.namingPolicy, settings.lookupPolicy)
         constants = SubstrateConstantsService(codecProvider.byteArray, lookup)
         storage = SubstrateStorageService(codecProvider.byteArray, lookup, modules.state)
         extrinsics = SubstrateExtrinsicsService(
@@ -94,7 +94,8 @@ class SubstrateClient(
             chainRpc = modules.chain,
             codec = codecProvider.byteArray,
             lookup = lookup,
-            namingPolicy = settings.namingPolicy
+            namingPolicy = settings.namingPolicy,
+            policy = settings.extrinsicsPolicy
         )
     }
 }

--- a/src/main/kotlin/dev/sublab/substrate/SubstrateClientExtrinsicsPolicy.kt
+++ b/src/main/kotlin/dev/sublab/substrate/SubstrateClientExtrinsicsPolicy.kt
@@ -1,0 +1,37 @@
+package dev.sublab.substrate
+
+import dev.sublab.substrate.extrinsics.NonceNotKnownException
+
+/**
+ * Policy with set of rules for Extrinsics service
+ */
+data class SubstrateClientExtrinsicsPolicy(
+    val nonceResolving: NonceResolvePolicy
+) {
+    /**
+     * Policy to determine what to do if nonce is unknown during signing extrinsic for an account which keeps zero balance
+     */
+    enum class NonceResolvePolicy {
+        THROW_ERROR_IF_UNKNOWN,
+        SET_TO_ZERO
+    };
+
+    companion object {
+        /**
+         * Unsafe Extrinsics policy with nonce being set to 0 if account is not found
+         */
+        fun unsafe() = SubstrateClientExtrinsicsPolicy(
+            nonceResolving = NonceResolvePolicy.SET_TO_ZERO
+        )
+
+        /**
+         * Safe Extrinsics policy with throwing [NonceNotKnownException] when couldn't resolve nonce
+         *
+         * Considered safe as this wouldn't create extrinsic with failing nonce for existing account with real nonce
+         * if resolving just failed
+         */
+        fun safe() = SubstrateClientExtrinsicsPolicy(
+            nonceResolving = NonceResolvePolicy.THROW_ERROR_IF_UNKNOWN
+        )
+    }
+}

--- a/src/main/kotlin/dev/sublab/substrate/SubstrateClientLookupPolicy.kt
+++ b/src/main/kotlin/dev/sublab/substrate/SubstrateClientLookupPolicy.kt
@@ -1,0 +1,34 @@
+package dev.sublab.substrate
+
+import dev.sublab.substrate.metadata.RuntimeMetadata
+
+/**
+ * Policy with set of rules for Lookup service
+ */
+data class SubstrateClientLookupPolicy(
+    val cachePolicy: CachePolicy
+) {
+    /**
+     * Policy to determine what to do with Lookup cache when [RuntimeMetadata] updates
+     */
+    enum class CachePolicy {
+        RESET_ON_METADATA_UPDATE,
+        KEEP_FOREVER
+    }
+
+    companion object {
+        /**
+         * Unsafe Lookup policy with cache being kept forever
+         */
+        fun unsafe() = SubstrateClientLookupPolicy(
+            cachePolicy = CachePolicy.KEEP_FOREVER
+        )
+
+        /**
+         * Safe Lookup policy with cache being reset on every [RuntimeMetadata] update
+         */
+        fun safe() = SubstrateClientLookupPolicy(
+            cachePolicy = CachePolicy.RESET_ON_METADATA_UPDATE
+        )
+    }
+}

--- a/src/main/kotlin/dev/sublab/substrate/SubstrateClientSettings.kt
+++ b/src/main/kotlin/dev/sublab/substrate/SubstrateClientSettings.kt
@@ -33,6 +33,8 @@ data class SubstrateClientSettings(
     val webSocketPort: Int?,
     val runtimeMetadataUpdateTimeoutMs: Long,
     val namingPolicy: SubstrateClientNamingPolicy,
+    val lookupPolicy: SubstrateClientLookupPolicy,
+    val extrinsicsPolicy: SubstrateClientExtrinsicsPolicy,
     val objectStorageFactory: ObjectStorageFactory
 ) {
     companion object {
@@ -48,6 +50,8 @@ data class SubstrateClientSettings(
             webSocketPort = null,
             runtimeMetadataUpdateTimeoutMs = 3600 * 1000,
             namingPolicy = SubstrateClientNamingPolicy.CASE_INSENSITIVE,
+            lookupPolicy = SubstrateClientLookupPolicy.safe(),
+            extrinsicsPolicy = SubstrateClientExtrinsicsPolicy.safe(),
             objectStorageFactory = InMemoryObjectStorageFactory()
         )
     }

--- a/src/main/kotlin/dev/sublab/substrate/extrinsics/SignedPayload.kt
+++ b/src/main/kotlin/dev/sublab/substrate/extrinsics/SignedPayload.kt
@@ -19,7 +19,7 @@
 package dev.sublab.substrate.extrinsics
 
 import dev.sublab.common.numerics.UInt8
-import dev.sublab.encrypting.signing.SignatureEngine
+import dev.sublab.encrypting.signing.NamedSigner
 import dev.sublab.hashing.hashers.blake2b_256
 import dev.sublab.hashing.hashing
 import dev.sublab.hex.hex
@@ -49,7 +49,7 @@ internal class SignedPayload<T: Any>(
     internal val accountId: AccountId,
     internal val nonce: Index,
     internal val tip: Balance,
-    internal val signatureEngine: SignatureEngine
+    internal val signer: NamedSigner
 ): Payload {
     override val moduleName: String get() = payload.moduleName
     override val callName: String get() = payload.callName
@@ -69,8 +69,8 @@ internal class SignedPayload<T: Any>(
 //            if (size > 256) signatureEngine.sign(hashing.blake2b_256())
 //            else signatureEngine.sign(this)
 //                .hex.encode(true)}")
-        if (size > 256) signatureEngine.sign(hashing.blake2b_256())
-        else signatureEngine.sign(this)
+        if (size > 256) signer.sign(hashing.blake2b_256())
+        else signer.sign(this)
     }
 
 //    private fun makeExtrinsic() = Extrinsic(
@@ -139,7 +139,7 @@ private fun <T: Any, Data: Any> ScaleCodecTransaction<Data>.appendSignature(sign
         ?: throw ExtrinsicBuildFailedDueToLookupFailureException()
 
     val signatureTypeIndex = signatureVariants.firstOrNull {
-        it.name.lowercase() == signedPayload.signatureEngine.name.lowercase()
+        it.name.lowercase() == signedPayload.signer.name.lowercase()
     }?.indexUInt8 ?: throw ExtrinsicBuildFailedDueToLookupFailureException()
 
 //    println("[signature] index: $signatureTypeIndex]")

--- a/src/main/kotlin/dev/sublab/substrate/metadata/modules/RuntimeModule.kt
+++ b/src/main/kotlin/dev/sublab/substrate/metadata/modules/RuntimeModule.kt
@@ -31,6 +31,5 @@ data class RuntimeModule(
     val errorsIndex: BigInteger?,
     val indexUInt8: UInt8
 ) {
-
     val index: UInt32 get() = indexUInt8.toUInt()
 }

--- a/src/main/kotlin/dev/sublab/substrate/modules/DefaultModuleProvider.kt
+++ b/src/main/kotlin/dev/sublab/substrate/modules/DefaultModuleProvider.kt
@@ -18,7 +18,6 @@
 
 package dev.sublab.substrate.modules
 
-import com.sun.net.httpserver.Filter.Chain
 import dev.sublab.substrate.ScaleCodecProvider
 import dev.sublab.substrate.SubstrateClient
 import dev.sublab.substrate.hashers.HashersProvider
@@ -45,7 +44,7 @@ class DefaultModuleProvider(
     override val chain: ChainModule get() = ChainModuleClient(rpc)
     override val state: StateModule get() = StateModuleClient(codecProvider.hex, rpc, hashersProvider)
     override val system: SystemModule get() = SystemModuleClient(client.constants, client.storage)
-    override val payment: PaymentModule get() = PaymentModuleClient(codecProvider.hex, rpc)
+    override val payment: PaymentModule get() = PaymentModuleClient(rpc)
 
     // Supply dependencies
     /**

--- a/src/main/kotlin/dev/sublab/substrate/modules/chain/ChainModule.kt
+++ b/src/main/kotlin/dev/sublab/substrate/modules/chain/ChainModule.kt
@@ -35,9 +35,7 @@ interface ChainModule {
 /**
  * Handles chain block hash fetching
  */
-class ChainModuleClient(
-    private val rpc: Rpc
-    ): ChainModule {
+class ChainModuleClient(private val rpc: Rpc): ChainModule {
     override suspend fun getBlockHash(number: Int) = rpc.sendRequest<String, String> {
         method = "chain_getBlockHash"
         responseType = String::class

--- a/src/main/kotlin/dev/sublab/substrate/modules/crowdloan/calls/AddMemo.kt
+++ b/src/main/kotlin/dev/sublab/substrate/modules/crowdloan/calls/AddMemo.kt
@@ -21,9 +21,10 @@ package dev.sublab.substrate.modules.crowdloan.calls
 import dev.sublab.common.numerics.UInt32
 import dev.sublab.substrate.extrinsics.Call
 
-internal data class AddMemo(val index: UInt32, val memo: ByteArray)
+@Suppress("ArrayInDataClass")
+data class AddMemo(val index: UInt32, val memo: ByteArray)
 
-internal class AddMemoCall(value: AddMemo) : Call<AddMemo>(
+class AddMemoCall(value: AddMemo) : Call<AddMemo>(
     moduleName = "crowdloan",
     name = "add_memo",
     value = value,

--- a/src/main/kotlin/dev/sublab/substrate/modules/payment/PaymentModule.kt
+++ b/src/main/kotlin/dev/sublab/substrate/modules/payment/PaymentModule.kt
@@ -19,7 +19,6 @@
 package dev.sublab.substrate.modules.payment
 
 import dev.sublab.hex.hex
-import dev.sublab.substrate.HexScaleCodec
 import dev.sublab.substrate.extrinsics.Payload
 import dev.sublab.substrate.modules.payment.types.QueryFeeDetails
 import dev.sublab.substrate.modules.payment.types.QueryFeeDetailsResponse
@@ -41,7 +40,6 @@ interface PaymentModule {
  * Handles payment query fee details fetching
  */
 class PaymentModuleClient(
-    private val codec: HexScaleCodec,
     private val rpc: Rpc
 ): PaymentModule {
     override suspend fun getQueryFeeDetails(payload: Payload) = rpc.sendRequest<String, QueryFeeDetailsResponse> {

--- a/src/main/kotlin/dev/sublab/substrate/modules/system/SystemModule.kt
+++ b/src/main/kotlin/dev/sublab/substrate/modules/system/SystemModule.kt
@@ -31,37 +31,37 @@ import dev.sublab.substrate.modules.system.storage.Account
 import kotlinx.coroutines.flow.first
 
 interface SystemModule {
-    suspend fun runtimeVersion(): RuntimeVersion?
-    suspend fun accountByAccountId(accountId: ByteArrayConvertible): Account?
-    suspend fun accountByAccountId(accountId: AccountId): Account?
-    suspend fun accountByAccountId(accountIdHex: String): Account?
-    suspend fun accountByPublicKey(publicKey: ByteArray): Account?
-    suspend fun accountByPublicKey(publicKeyHex: String): Account?
-    suspend fun accountByKeyPair(keyPair: KeyPair): Account?
+    suspend fun getRuntimeVersion(): RuntimeVersion?
+    suspend fun getAccountByAccountId(accountId: ByteArrayConvertible): Account?
+    suspend fun getAccountByAccountId(accountId: AccountId): Account?
+    suspend fun getAccountByAccountId(accountIdHex: String): Account?
+    suspend fun getAccountByPublicKey(publicKey: ByteArray): Account?
+    suspend fun getAccountByPublicKey(publicKeyHex: String): Account?
+    suspend fun getAccountByKeyPair(keyPair: KeyPair): Account?
 }
 
 class SystemModuleClient(
     private val constants: SubstrateConstants,
     private val storage: SubstrateStorage
 ): SystemModule {
-    override suspend fun runtimeVersion() = constants
+    override suspend fun getRuntimeVersion() = constants
         .fetch("system", "version", RuntimeVersion::class).first()
 
-    override suspend fun accountByAccountId(accountId: ByteArrayConvertible) = storage
+    override suspend fun getAccountByAccountId(accountId: ByteArrayConvertible) = storage
         .fetch("system", "account", accountId, Account::class).first()
 
-    override suspend fun accountByAccountId(accountId: AccountId)
-        = accountByAccountId(accountId.asByteArrayConvertible())
+    override suspend fun getAccountByAccountId(accountId: AccountId)
+        = getAccountByAccountId(accountId.asByteArrayConvertible())
 
-    override suspend fun accountByAccountId(accountIdHex: String)
-            = accountByAccountId(accountIdHex.hex.decode())
+    override suspend fun getAccountByAccountId(accountIdHex: String)
+            = getAccountByAccountId(accountIdHex.hex.decode())
 
-    override suspend fun accountByPublicKey(publicKey: ByteArray)
-            = accountByAccountId(publicKey.ss58.accountId())
+    override suspend fun getAccountByPublicKey(publicKey: ByteArray)
+            = getAccountByAccountId(publicKey.ss58.accountId())
 
-    override suspend fun accountByPublicKey(publicKeyHex: String)
-            = accountByPublicKey(publicKeyHex.hex.decode())
+    override suspend fun getAccountByPublicKey(publicKeyHex: String)
+            = getAccountByPublicKey(publicKeyHex.hex.decode())
 
-    override suspend fun accountByKeyPair(keyPair: KeyPair)
-            = accountByPublicKey(keyPair.publicKey)
+    override suspend fun getAccountByKeyPair(keyPair: KeyPair)
+            = getAccountByPublicKey(keyPair.publicKey)
 }

--- a/src/main/kotlin/dev/sublab/substrate/rpcClient/RpcClient.kt
+++ b/src/main/kotlin/dev/sublab/substrate/rpcClient/RpcClient.kt
@@ -51,13 +51,13 @@ interface Rpc {
 /**
  * RPC client that handles sending requests
  */
-internal class RpcClient(
+class RpcClient(
     private val host: String,
     private val path: String? = null,
     private val params: Map<String, Any?> = mapOf()
 ): Rpc {
     // For testing purposes
-    internal companion object
+    internal companion object;
 
     private val httpClient = HttpClient(CIO) {
         install(ContentNegotiation) {

--- a/src/main/kotlin/dev/sublab/substrate/scale/DynamicUIntTypes.kt
+++ b/src/main/kotlin/dev/sublab/substrate/scale/DynamicUIntTypes.kt
@@ -27,6 +27,8 @@ import java.math.BigInteger
 @DynamicType(lookupIndex = 4)
 class Index(byteArray: ByteArray): FromByteArray(byteArray) {
     constructor(value: BigInteger) : this(value.toByteArray().reversedArray())
+    constructor(value: Int) : this(BigInteger.valueOf(value.toLong()))
+    constructor(value: Long) : this(BigInteger.valueOf(value))
 
     val value = BigInteger(byteArray.reversedArray())
     // Required to convert to and from actual type
@@ -38,6 +40,8 @@ class Index(byteArray: ByteArray): FromByteArray(byteArray) {
  */
 @DynamicType(lookupIndex = 6)
 class Balance(byteArray: ByteArray): FromByteArray(byteArray) {
+    constructor(value: Int) : this(BigInteger.valueOf(value.toLong()))
+    constructor(value: Long) : this(BigInteger.valueOf(value))
     constructor(value: BigInteger) : this(value.toByteArray().reversedArray())
 
     val value = BigInteger(byteArray.reversedArray())

--- a/src/test/kotlin/dev/sublab/substrate/TestExtrinsics.kt
+++ b/src/test/kotlin/dev/sublab/substrate/TestExtrinsics.kt
@@ -122,8 +122,8 @@ internal class TestExtrinsics {
 
         println("network: ${network}, signed: ${signed.toByteArray().hex.encode(true)}")
 
-        val queryFeeDetails = client.modules.payment.getQueryFeeDetails(signed)
-        assertNotNull(queryFeeDetails)
-        assert(queryFeeDetails.baseFee.value > BigInteger.ZERO)
+        val fee = client.modules.payment.getQueryFeeDetails(signed)
+        assertNotNull(fee)
+        assert(fee.baseFee.value > BigInteger.ZERO)
     }
 }

--- a/src/test/kotlin/dev/sublab/substrate/TestExtrinsics.kt
+++ b/src/test/kotlin/dev/sublab/substrate/TestExtrinsics.kt
@@ -117,7 +117,7 @@ internal class TestExtrinsics {
             tip = Balance(BigInteger("0")),
             accountId = keyPair.publicKey.ss58.accountId(),
             nonce = Index(BigInteger("0")),
-            signatureEngine = keyPair.getSignatureEngine(keyPair.privateKey)
+            signer = keyPair.getSignatureEngine(keyPair.privateKey)
         )
 
         println("network: ${network}, signed: ${signed.toByteArray().hex.encode(true)}")

--- a/src/test/kotlin/dev/sublab/substrate/TestRandomAccount.kt
+++ b/src/test/kotlin/dev/sublab/substrate/TestRandomAccount.kt
@@ -27,6 +27,7 @@ import dev.sublab.sr25519.sr25519
 import dev.sublab.ss58.ss58
 import dev.sublab.substrate.modules.system.storage.Account
 import dev.sublab.substrate.support.KusamaNetwork
+import dev.sublab.substrate.support.allKeyPairFactories
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
@@ -36,16 +37,9 @@ internal class TestRandomAccount {
     private val network = KusamaNetwork()
     private val client = network.makeClient()
 
-    private val factories = listOf(
-        KeyPair.Factory.ecdsa(Kind.SUBSTRATE),
-        KeyPair.Factory.ecdsa(Kind.ETHEREUM),
-        KeyPair.Factory.ed25519,
-        KeyPair.Factory.sr25519()
-    )
-
     @Test
     fun `no records about account in blockchain`() = runBlocking {
-        for (factory in factories) {
+        for (factory in allKeyPairFactories()) {
             val keyPair = factory.generate()
             val accountId = keyPair.publicKey.ss58.accountId().asByteArrayConvertible()
 

--- a/src/test/kotlin/dev/sublab/substrate/TestRuntimeMetadata.kt
+++ b/src/test/kotlin/dev/sublab/substrate/TestRuntimeMetadata.kt
@@ -83,7 +83,7 @@ internal class TestRuntimeMetadata {
     fun testRuntimeVersion() = runBlocking {
         for (network in allNetworks()) {
             val client = network.makeClient()
-            val runtimeVersion = client.modules.system.runtimeVersion()
+            val runtimeVersion = client.modules.system.getRuntimeVersion()
             assertNotNull(runtimeVersion)
         }
     }

--- a/src/test/kotlin/dev/sublab/substrate/modules/TestChainModule.kt
+++ b/src/test/kotlin/dev/sublab/substrate/modules/TestChainModule.kt
@@ -1,0 +1,24 @@
+package dev.sublab.substrate.modules
+
+import dev.sublab.substrate.support.Network
+import dev.sublab.substrate.support.allNetworks
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+internal class TestChainModule {
+    @Test
+    fun `test genesis hashes for all networks`() {
+        for (network in allNetworks()) {
+            checkGenesisHash(network)
+        }
+    }
+
+    private fun checkGenesisHash(network: Network) = runBlocking {
+        val client = network.makeClient()
+        val genesisHash = client.modules.chain.getBlockHash(0)
+        assertNotNull(genesisHash)
+        assertEquals(network.genesisHash, genesisHash)
+    }
+}

--- a/src/test/kotlin/dev/sublab/substrate/modules/TestCrowdloanModule.kt
+++ b/src/test/kotlin/dev/sublab/substrate/modules/TestCrowdloanModule.kt
@@ -1,0 +1,33 @@
+package dev.sublab.substrate.modules
+
+import dev.sublab.encrypting.keys.KeyPair
+import dev.sublab.sr25519.sr25519
+import dev.sublab.substrate.modules.crowdloan.calls.AddMemo
+import dev.sublab.substrate.modules.crowdloan.calls.AddMemoCall
+import dev.sublab.substrate.support.KusamaNetwork
+import extra.kotlin.util.UUID
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import java.math.BigInteger
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class TestCrowdloanModule {
+    private val network = KusamaNetwork()
+    private val client = network.makeClient()
+
+    @Test
+    fun `add memo`() = runTest {
+        val addMemo = AddMemoCall(AddMemo(0u, UUID.uuid4().toString().toByteArray()))
+        val keyPair = KeyPair.sr25519().generate()
+
+        val extrinsic = client.extrinsics.makeSigned(call = addMemo, keyPair = keyPair)
+        assertNotNull(extrinsic)
+
+        val fee = client.modules.payment.getQueryFeeDetails(extrinsic)
+        assertNotNull(fee)
+
+        assert(fee.baseFee.value > BigInteger.ZERO)
+    }
+}

--- a/src/test/kotlin/dev/sublab/substrate/modules/TestSystemModule.kt
+++ b/src/test/kotlin/dev/sublab/substrate/modules/TestSystemModule.kt
@@ -1,0 +1,76 @@
+package dev.sublab.substrate.modules
+
+import dev.sublab.common.asByteArrayConvertible
+import dev.sublab.hex.hex
+import dev.sublab.ss58.ss58
+import dev.sublab.substrate.support.KusamaNetwork
+import dev.sublab.substrate.support.allKeyPairFactories
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+internal class TestSystemModule {
+    private val network = KusamaNetwork()
+    private val client = network.makeClient()
+    private val module get() = client.modules.system
+
+    @Test
+    fun `runtime version`(): Unit = runBlocking {
+        val runtimeVersion = module.getRuntimeVersion()
+        assertNotNull(runtimeVersion)
+    }
+
+    @Test
+    fun `no account for key pair`() = runBlocking {
+        for (factory in allKeyPairFactories()) {
+            val keyPair = factory.generate()
+            val account = module.getAccountByKeyPair(keyPair)
+            assertNull(account)
+        }
+    }
+
+    @Test
+    fun `no account for public key`() = runBlocking {
+        for (factory in allKeyPairFactories()) {
+            val keyPair = factory.generate()
+            val account = module.getAccountByPublicKey(keyPair.publicKey)
+            assertNull(account)
+        }
+    }
+
+    @Test
+    fun `no account for public key hex`() = runBlocking {
+        for (factory in allKeyPairFactories()) {
+            val keyPair = factory.generate()
+            val account = module.getAccountByPublicKey(keyPair.publicKey.hex.encode(true))
+            assertNull(account)
+        }
+    }
+
+    private val accountIds get() = allKeyPairFactories().map { it.generate().publicKey.ss58.accountId() }
+
+    @Test
+    fun `no account for account id`() = runBlocking {
+        for (accountId in accountIds) {
+            val account = module.getAccountByAccountId(accountId)
+            assertNull(account)
+        }
+    }
+
+    @Test
+    fun `no account for account id hex`() = runBlocking {
+        for (accountId in accountIds) {
+            val account = module.getAccountByAccountId(accountId.hex.encode(true))
+            assertNull(account)
+        }
+    }
+
+    @Test
+    fun `no account for account id as byte array convertible`() = runBlocking {
+        for (accountId in accountIds) {
+            val account = module.getAccountByAccountId(accountId.asByteArrayConvertible())
+            assertNull(account)
+        }
+    }
+}

--- a/src/test/kotlin/dev/sublab/substrate/support/Accounts.kt
+++ b/src/test/kotlin/dev/sublab/substrate/support/Accounts.kt
@@ -1,0 +1,14 @@
+package dev.sublab.substrate.support
+
+import dev.sublab.ecdsa.Kind
+import dev.sublab.ecdsa.ecdsa
+import dev.sublab.ed25519.ed25519
+import dev.sublab.encrypting.keys.KeyPair
+import dev.sublab.sr25519.sr25519
+
+internal fun allKeyPairFactories() = listOf(
+    KeyPair.Factory.ecdsa(Kind.SUBSTRATE),
+    KeyPair.Factory.ecdsa(Kind.ETHEREUM),
+    KeyPair.Factory.ed25519,
+    KeyPair.Factory.sr25519()
+)

--- a/src/test/kotlin/dev/sublab/substrate/support/AssertCoroutines.kt
+++ b/src/test/kotlin/dev/sublab/substrate/support/AssertCoroutines.kt
@@ -1,0 +1,15 @@
+package dev.sublab.substrate.support
+
+import kotlinx.coroutines.runBlocking
+import org.opentest4j.AssertionFailedError
+
+internal inline fun <reified T : Throwable> assertThrowsBlocking(crossinline executable: suspend () -> Unit) = runBlocking {
+    try {
+        executable()
+    } catch (throwable: Throwable) {
+        if (throwable !is T) {
+            val message = "Unexpected exception type thrown: $throwable"
+            throw AssertionFailedError(message, throwable)
+        }
+    }
+}

--- a/src/test/kotlin/dev/sublab/substrate/support/Networks.kt
+++ b/src/test/kotlin/dev/sublab/substrate/support/Networks.kt
@@ -20,6 +20,8 @@ package dev.sublab.substrate.support
 
 import dev.sublab.common.numerics.UInt32
 import dev.sublab.substrate.SubstrateClient
+import dev.sublab.substrate.SubstrateClientExtrinsicsPolicy
+import dev.sublab.substrate.SubstrateClientLookupPolicy
 import dev.sublab.substrate.SubstrateClientSettings
 import dev.sublab.substrate.rpcClient.RpcClient
 
@@ -86,6 +88,8 @@ private fun makeSettings() = SubstrateClientSettings.default().let { default ->
         webSocketPort = null,
         runtimeMetadataUpdateTimeoutMs = default.runtimeMetadataUpdateTimeoutMs,
         namingPolicy = default.namingPolicy,
+        lookupPolicy = SubstrateClientLookupPolicy.unsafe(),
+        extrinsicsPolicy = SubstrateClientExtrinsicsPolicy.unsafe(),
         objectStorageFactory = default.objectStorageFactory
     )
 }


### PR DESCRIPTION
- Removed Android coroutines dependency
- Made several components public for developers' use 
- Renamed methods in System module to Java-way
- Added convenience constructors to Index and Balance 
- Added separate policies for Lookup and Extrinsics services 
- Set tip to be defaulted to 0 in Extrinsics service 
- Added missing functions coverage tests to Chain, Crowdloan, System modules 
- Added coroutines helper function to assert throws (currently unused)